### PR TITLE
fix dev building

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,13 +1,17 @@
 module.exports = function override (config, env) {
     let loaders = config.resolve;
     loaders.fallback = {
-        "stream": false,
+        stream: false,
+        crypto: false,
     };
-    config.optimization = {
-        splitChunks: {
-            chunks: 'all',
-        },
-    };
+    if (env !== 'development') {
+        config.optimization = {
+            splitChunks: {
+                chunks: 'all',
+            },
+        };
+    }
+    config.ignoreWarnings = [/Failed to parse source map/];
     
     return config
 }


### PR DESCRIPTION
@stephenandrews does this fix `npm start` for you? I was able to repro `npm start` hanging and this fixes it for me while keeping the production build healthy.

  - Prevent chunking in dev mode.
  - Don't polyfill Node.js crypto module for frontend. We never import it (same as the `stream` module which also is ignored in the config override.)
    - Note that production builds didn't complain about it missing so this is fine. No need to increase bundle size.
  - Ignore missing source maps from `node_modules` since we can't do much about that.