### PR TITLE
remove fixed token count for the fool

### DIFF
--- a/src/ic/extjs.js
+++ b/src/ic/extjs.js
@@ -77,7 +77,6 @@ const _preloadedIdls = {
 var tokensToLoad = {
   "pk6rk-6aaaa-aaaae-qaazq-cai" : [0,2009],
   "jmuqr-yqaaa-aaaaj-qaicq-cai" : [0,3507],
-  "nges7-giaaa-aaaaj-qaiya-cai" : [0,100],
   "jeghr-iaaaa-aaaah-qco7q-cai" : [0,10000],
   "y3b7h-siaaa-aaaah-qcnwa-cai" : [0,10000],
   "bxdf4-baaaa-aaaah-qaruq-cai" : [1,10000],


### PR DESCRIPTION
A fixed token count was put in place due to a missing method on The Fool canister. This missing method has been resolved, and removing this fixed value hack now correctly displays all of the tokens in the canister.

**Before:**

![image](https://user-images.githubusercontent.com/60938577/157915570-882fb6fe-bd51-4f18-afcb-f3186acb531a.png)

*Shows 100 as supply, but real number is 117. Doesn't list tokens above 100.*

**After:**

![image](https://user-images.githubusercontent.com/60938577/157915408-cf05f355-14bd-4d1e-a0cd-56801e44299e.png)

*Correctly showing supply of 117, and tokens above 100 are now listed.*