### PR TITLE
update fleek-iterative-deploy dependency

### DIFF
--- a/.github/workflows/fleek-iterative-deploy.yml
+++ b/.github/workflows/fleek-iterative-deploy.yml
@@ -6,15 +6,20 @@ on:
             - 'main'
 
 jobs:
-    build:
+    fleek-iterative-deploy:
         runs-on: ${{ matrix.os }}
         strategy:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
                 node-version: [16.x]
+        concurrency:
+            group: 'fleek-deploy'
+            cancel-in-progress: true
         steps:
             - uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v3
               with:
@@ -27,4 +32,4 @@ jobs:
                   GENERATE_SOURCEMAP: false
               run: |
                   npm ci
-                  npx fleek-iterative-deploy
+                  npx @toniq-labs/fleek-iterative-deploy

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
-        "fleek-iterative-deploy": "1.2.2",
+        "@toniq-labs/fleek-iterative-deploy": "1.2.11",
         "react-app-rewired": "^2.1.11",
         "redux": "^4.1.2",
         "serve": "^13.0.2",
@@ -4653,6 +4653,22 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@toniq-labs/fleek-iterative-deploy": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@toniq-labs/fleek-iterative-deploy/-/fleek-iterative-deploy-1.2.11.tgz",
+      "integrity": "sha512-6QMkNs5nc/VcQKSYjEl8AIBRefrcVznU3ZXd0f0qcvfpzThc/uuzApEkQKtMgQUIcgMFGaFnc2mjHE06D0qrGg==",
+      "dev": true,
+      "dependencies": {
+        "@fleekhq/fleek-cli": "0.1.8",
+        "augment-vir": "1.12.2",
+        "fs-extra": "10.1.0",
+        "graphql": "16.3.0",
+        "graphql-request": "4.2.0"
+      },
+      "bin": {
+        "fleek-iterative-deploy": "dist/cli.js"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -6094,26 +6110,12 @@
       }
     },
     "node_modules/augment-vir": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/augment-vir/-/augment-vir-1.12.1.tgz",
-      "integrity": "sha512-w7NWMQ1G0b+H8tQA5wgL5cycoZ32pK8BlgKeLIZzvA34s4+WYFxQrxiCgSeFDbNxVdhR7mVQXcpNR1YCLxxvmA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/augment-vir/-/augment-vir-1.12.2.tgz",
+      "integrity": "sha512-W7fkv/JqViIi70CJTPW3/cpJyJ5fFgHKgfBmdWHToFykdJhxztXxBXoZZ2UDePCEh7ffTWn0KIQ7AEMFGZtesw==",
       "dev": true,
       "dependencies": {
-        "fs-extra": "10.0.1"
-      }
-    },
-    "node_modules/augment-vir/node_modules/fs-extra": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
-      "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
+        "fs-extra": "10.1.0"
       }
     },
     "node_modules/auto-bind": {
@@ -10621,36 +10623,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
     },
-    "node_modules/fleek-iterative-deploy": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/fleek-iterative-deploy/-/fleek-iterative-deploy-1.2.2.tgz",
-      "integrity": "sha512-ClMGLtOLLMlAH0QQKoX9VFsTgky9BmhP1SygkvNXvgpFz9Q8a8HUUPNvzHNaPpUsWeKOONDeqoArMALl77DOgw==",
-      "dev": true,
-      "dependencies": {
-        "@fleekhq/fleek-cli": "0.1.8",
-        "augment-vir": "1.12.1",
-        "fs-extra": "10.0.1",
-        "graphql": "16.3.0",
-        "graphql-request": "4.2.0"
-      },
-      "bin": {
-        "fleek-iterative-deploy": "dist/cli.js"
-      }
-    },
-    "node_modules/fleek-iterative-deploy/node_modules/fs-extra": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
-      "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/follow-redirects": {
       "version": "1.14.7",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
@@ -10933,9 +10905,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -26378,6 +26350,19 @@
         "@babel/runtime": "^7.12.5"
       }
     },
+    "@toniq-labs/fleek-iterative-deploy": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@toniq-labs/fleek-iterative-deploy/-/fleek-iterative-deploy-1.2.11.tgz",
+      "integrity": "sha512-6QMkNs5nc/VcQKSYjEl8AIBRefrcVznU3ZXd0f0qcvfpzThc/uuzApEkQKtMgQUIcgMFGaFnc2mjHE06D0qrGg==",
+      "dev": true,
+      "requires": {
+        "@fleekhq/fleek-cli": "0.1.8",
+        "augment-vir": "1.12.2",
+        "fs-extra": "10.1.0",
+        "graphql": "16.3.0",
+        "graphql-request": "4.2.0"
+      }
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -27557,25 +27542,12 @@
       "dev": true
     },
     "augment-vir": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/augment-vir/-/augment-vir-1.12.1.tgz",
-      "integrity": "sha512-w7NWMQ1G0b+H8tQA5wgL5cycoZ32pK8BlgKeLIZzvA34s4+WYFxQrxiCgSeFDbNxVdhR7mVQXcpNR1YCLxxvmA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/augment-vir/-/augment-vir-1.12.2.tgz",
+      "integrity": "sha512-W7fkv/JqViIi70CJTPW3/cpJyJ5fFgHKgfBmdWHToFykdJhxztXxBXoZZ2UDePCEh7ffTWn0KIQ7AEMFGZtesw==",
       "dev": true,
       "requires": {
-        "fs-extra": "10.0.1"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
-          "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        }
+        "fs-extra": "10.1.0"
       }
     },
     "auto-bind": {
@@ -31150,32 +31122,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
     },
-    "fleek-iterative-deploy": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/fleek-iterative-deploy/-/fleek-iterative-deploy-1.2.2.tgz",
-      "integrity": "sha512-ClMGLtOLLMlAH0QQKoX9VFsTgky9BmhP1SygkvNXvgpFz9Q8a8HUUPNvzHNaPpUsWeKOONDeqoArMALl77DOgw==",
-      "dev": true,
-      "requires": {
-        "@fleekhq/fleek-cli": "0.1.8",
-        "augment-vir": "1.12.1",
-        "fs-extra": "10.0.1",
-        "graphql": "16.3.0",
-        "graphql-request": "4.2.0"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
-          "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        }
-      }
-    },
     "follow-redirects": {
       "version": "1.14.7",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
@@ -31355,9 +31301,9 @@
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fs-extra": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "requires": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     ]
   },
   "devDependencies": {
-    "fleek-iterative-deploy": "1.2.2",
+    "@toniq-labs/fleek-iterative-deploy": "1.2.11",
     "react-app-rewired": "^2.1.11",
     "redux": "^4.1.2",
     "serve": "^13.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2021,6 +2021,17 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
 
+"@toniq-labs/fleek-iterative-deploy@1.2.11":
+  "integrity" "sha512-6QMkNs5nc/VcQKSYjEl8AIBRefrcVznU3ZXd0f0qcvfpzThc/uuzApEkQKtMgQUIcgMFGaFnc2mjHE06D0qrGg=="
+  "resolved" "https://registry.npmjs.org/@toniq-labs/fleek-iterative-deploy/-/fleek-iterative-deploy-1.2.11.tgz"
+  "version" "1.2.11"
+  dependencies:
+    "@fleekhq/fleek-cli" "0.1.8"
+    "augment-vir" "1.12.2"
+    "fs-extra" "10.1.0"
+    "graphql" "16.3.0"
+    "graphql-request" "4.2.0"
+
 "@tootallnate/once@1":
   "integrity" "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
   "resolved" "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz"
@@ -3194,12 +3205,12 @@
   "resolved" "https://registry.npmjs.org/atomically/-/atomically-1.7.0.tgz"
   "version" "1.7.0"
 
-"augment-vir@1.12.1":
-  "integrity" "sha512-w7NWMQ1G0b+H8tQA5wgL5cycoZ32pK8BlgKeLIZzvA34s4+WYFxQrxiCgSeFDbNxVdhR7mVQXcpNR1YCLxxvmA=="
-  "resolved" "https://registry.npmjs.org/augment-vir/-/augment-vir-1.12.1.tgz"
-  "version" "1.12.1"
+"augment-vir@1.12.2":
+  "integrity" "sha512-W7fkv/JqViIi70CJTPW3/cpJyJ5fFgHKgfBmdWHToFykdJhxztXxBXoZZ2UDePCEh7ffTWn0KIQ7AEMFGZtesw=="
+  "resolved" "https://registry.npmjs.org/augment-vir/-/augment-vir-1.12.2.tgz"
+  "version" "1.12.2"
   dependencies:
-    "fs-extra" "10.0.1"
+    "fs-extra" "10.1.0"
 
 "auto-bind@^2.1.1":
   "integrity" "sha512-NUwV1i9D3vxxY1KnfZgSZ716d6ovY7o8LfOwLhGIPFBowIb6Ln6DBW64+jCqPzUznel2hRSkQnYQqvh7/ldw8A=="
@@ -6185,17 +6196,6 @@
   "resolved" "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz"
   "version" "3.2.5"
 
-"fleek-iterative-deploy@1.2.2":
-  "integrity" "sha512-ClMGLtOLLMlAH0QQKoX9VFsTgky9BmhP1SygkvNXvgpFz9Q8a8HUUPNvzHNaPpUsWeKOONDeqoArMALl77DOgw=="
-  "resolved" "https://registry.npmjs.org/fleek-iterative-deploy/-/fleek-iterative-deploy-1.2.2.tgz"
-  "version" "1.2.2"
-  dependencies:
-    "@fleekhq/fleek-cli" "0.1.8"
-    "augment-vir" "1.12.1"
-    "fs-extra" "10.0.1"
-    "graphql" "16.3.0"
-    "graphql-request" "4.2.0"
-
 "follow-redirects@^1.0.0", "follow-redirects@^1.14.0", "follow-redirects@^1.14.7":
   "integrity" "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
   "resolved" "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz"
@@ -6272,10 +6272,10 @@
   "resolved" "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
   "version" "0.5.2"
 
-"fs-extra@^10.0.0":
-  "integrity" "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ=="
-  "resolved" "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz"
-  "version" "10.0.0"
+"fs-extra@^10.0.0", "fs-extra@10.1.0":
+  "integrity" "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="
+  "resolved" "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz"
+  "version" "10.1.0"
   dependencies:
     "graceful-fs" "^4.2.0"
     "jsonfile" "^6.0.1"
@@ -6315,15 +6315,6 @@
   "version" "9.1.0"
   dependencies:
     "at-least-node" "^1.0.0"
-    "graceful-fs" "^4.2.0"
-    "jsonfile" "^6.0.1"
-    "universalify" "^2.0.0"
-
-"fs-extra@10.0.1":
-  "integrity" "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag=="
-  "resolved" "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz"
-  "version" "10.0.1"
-  dependencies:
     "graceful-fs" "^4.2.0"
     "jsonfile" "^6.0.1"
     "universalify" "^2.0.0"


### PR DESCRIPTION
- Update `fleek-iterative-deploy` dependency to use the new version under the Toniq Labs org: [`@toniq-labs/fleek-iterative-deploy`](https://www.npmjs.com/package/@toniq-labs/fleek-iterative-deploy)
- Small tweaks to improve GitHub Action workflow.
- Successfully run on my fork here: https://github.com/electrovir/entrepot-app/actions/runs/2214572294