### PR TITLE
Block countries with Netlify

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,2 @@
+/* /access-denied-403.html 403 Country=cf,cu,ir,kp,sy
 /* /index.html 200

--- a/public/access-denied-403.html
+++ b/public/access-denied-403.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <style>
+      body {
+        font-family: sans-serif;
+      }
+    </style>
+  </head>
+  <body>
+    403: Access Denied
+  </body>
+</html>

--- a/src/App.js
+++ b/src/App.js
@@ -34,6 +34,7 @@ import DfinityDeckSaleComponent from "./components/sale/DfinityDeckSaleComponent
 import legacyPrincipalPayouts from './payments.json';
 import getNri from "./ic/nftv.js";
 import { EntrepotUpdateUSD, EntrepotUpdateLiked, EntrepotClearLiked, EntrepotUpdateStats } from './utils';
+import { MissingPage404 } from './views/MissingPage404';
 const api = extjs.connect("https://boundary.ic0.app/");
 const txfee = 10000;
 const txmin = 100000;
@@ -945,6 +946,7 @@ export default function App() {
                   confirm={confirm}
                   loader={loader} balance={balance} identity={identity}  account={accounts.length > 0 ? accounts[currentAccount] : false} logout={logout} login={login} collections={collections} collection={false} currentAccount={currentAccount} changeAccount={setCurrentAccount} accounts={accounts}
                 />} />
+                <Route path="*" element={<MissingPage404 />} />
             </Routes>
             <BuyForm open={showBuyForm} {...buyFormData} />
             <TransferForm refresher={refresher} buttonLoader={buttonLoader} transfer={transfer} alert={alert} open={openTransferForm} close={closeTransferForm} loader={loader} error={error} nft={tokenNFT} />

--- a/src/views/MissingPage404.js
+++ b/src/views/MissingPage404.js
@@ -1,0 +1,11 @@
+import React from "react";
+
+export function MissingPage404() {
+  return (
+    <>
+      <h1>
+        404: Missing page
+      </h1>
+    </>
+  );
+}


### PR DESCRIPTION
Block specific countries from accessing Entrepot entirely, following Netlify's guide: https://docs.netlify.com/routing/redirects/redirect-options/#redirect-by-country-or-language

- [x] Remove `mx` and `sg` before merging. Those countries will not be blocked, we are just testing it.