### PR TITLE
Prevent user balance from shifting nav bar buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@testing-library/jest-dom": "^5.16.1",
         "@testing-library/react": "^12.1.2",
         "@testing-library/user-event": "^13.5.0",
-        "@toniq-labs/design-system": "0.0.14",
+        "@toniq-labs/design-system": "0.0.15",
         "@toruslabs/openlogin": "^1.4.0",
         "assert": "^2.0.0",
         "axios": "^0.25.0",
@@ -4660,9 +4660,9 @@
       }
     },
     "node_modules/@toniq-labs/design-system": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@toniq-labs/design-system/-/design-system-0.0.14.tgz",
-      "integrity": "sha512-6Ckjg5iPu9faSSsbYUx32q1TS/GmJ9Q2Sxp4EyMQp+Jikacf8i00WBtut0WzL2ooP0ez7l88sPoohPt0CzFb0Q==",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@toniq-labs/design-system/-/design-system-0.0.15.tgz",
+      "integrity": "sha512-NI2yXXQcgjo2WP6MH0RRBs1ieyBR6k31mcDBVGvU1t4ajLU+/IOr2P5exJ5qwNYcKkkEWTa5KpG49KCNXYczsg==",
       "hasInstallScript": true,
       "dependencies": {
         "augment-vir": "2.2.1",
@@ -26435,9 +26435,9 @@
       }
     },
     "@toniq-labs/design-system": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@toniq-labs/design-system/-/design-system-0.0.14.tgz",
-      "integrity": "sha512-6Ckjg5iPu9faSSsbYUx32q1TS/GmJ9Q2Sxp4EyMQp+Jikacf8i00WBtut0WzL2ooP0ez7l88sPoohPt0CzFb0Q==",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@toniq-labs/design-system/-/design-system-0.0.15.tgz",
+      "integrity": "sha512-NI2yXXQcgjo2WP6MH0RRBs1ieyBR6k31mcDBVGvU1t4ajLU+/IOr2P5exJ5qwNYcKkkEWTa5KpG49KCNXYczsg==",
       "requires": {
         "augment-vir": "2.2.1",
         "element-vir": "5.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@testing-library/jest-dom": "^5.16.1",
         "@testing-library/react": "^12.1.2",
         "@testing-library/user-event": "^13.5.0",
-        "@toniq-labs/design-system": "0.0.11",
+        "@toniq-labs/design-system": "0.0.14",
         "@toruslabs/openlogin": "^1.4.0",
         "assert": "^2.0.0",
         "axios": "^0.25.0",
@@ -3038,9 +3038,9 @@
       "integrity": "sha512-KUidDSb+K7Rkoy2uJ/HdCnt4soNRlhNXONU8r8Cgic6Qq3E9BPg4kMSYXchM37WpYvGEGq2NUq/kCegMSLhtIg=="
     },
     "node_modules/@lit/reactive-element": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.3.2.tgz",
-      "integrity": "sha512-A2e18XzPMrIh35nhIdE4uoqRzoIpEU5vZYuQN4S3Ee1zkGdYC27DP12pewbw/RLgPHzaE4kx/YqxMzebOpm0dA=="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.3.4.tgz",
+      "integrity": "sha512-I1wz4uxOA52zSBhKmv4KQWLJpCyvfpnDg+eQR6mjpRgV+Ldi14HLPpSUpJklZRldz0fFmGCC/kVmuc/3cPFqCg=="
     },
     "node_modules/@material-ui/core": {
       "version": "4.12.2",
@@ -4660,9 +4660,9 @@
       }
     },
     "node_modules/@toniq-labs/design-system": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@toniq-labs/design-system/-/design-system-0.0.11.tgz",
-      "integrity": "sha512-883X5qIZ73YhbtdYuXh+TfpKB6/GH7jZbcdBpiwIlzluzE3zH8878zA+w9jXbFF/Vow5r45m5aZAy8UtFDGeeg==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@toniq-labs/design-system/-/design-system-0.0.14.tgz",
+      "integrity": "sha512-6Ckjg5iPu9faSSsbYUx32q1TS/GmJ9Q2Sxp4EyMQp+Jikacf8i00WBtut0WzL2ooP0ez7l88sPoohPt0CzFb0Q==",
       "hasInstallScript": true,
       "dependencies": {
         "augment-vir": "2.2.1",
@@ -15613,18 +15613,18 @@
       }
     },
     "node_modules/lit-element": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.2.0.tgz",
-      "integrity": "sha512-HbE7yt2SnUtg5DCrWt028oaU4D5F4k/1cntAFHTkzY8ZIa8N0Wmu92PxSxucsQSOXlODFrICkQ5x/tEshKi13g==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.2.2.tgz",
+      "integrity": "sha512-6ZgxBR9KNroqKb6+htkyBwD90XGRiqKDHVrW/Eh0EZ+l+iC+u+v+w3/BA5NGi4nizAVHGYvQBHUDuSmLjPp7NQ==",
       "dependencies": {
         "@lit/reactive-element": "^1.3.0",
         "lit-html": "^2.2.0"
       }
     },
     "node_modules/lit-html": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.6.tgz",
-      "integrity": "sha512-xOKsPmq/RAKJ6dUeOxhmOYFjcjf0Q7aSdfBJgdJkOfCUnkmmJPxNrlZpRBeVe1Gg50oYWMlgm6ccAE/SpJgSdw==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.7.tgz",
+      "integrity": "sha512-JhqiAwO1l03kRe68uBZ0i2x4ef2S5szY9vvP411nlrFZIpKK4/hwnhA/15bqbvxe1lV3ipBdhaOzHmyOk7QIRg==",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -25368,9 +25368,9 @@
       "integrity": "sha512-KUidDSb+K7Rkoy2uJ/HdCnt4soNRlhNXONU8r8Cgic6Qq3E9BPg4kMSYXchM37WpYvGEGq2NUq/kCegMSLhtIg=="
     },
     "@lit/reactive-element": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.3.2.tgz",
-      "integrity": "sha512-A2e18XzPMrIh35nhIdE4uoqRzoIpEU5vZYuQN4S3Ee1zkGdYC27DP12pewbw/RLgPHzaE4kx/YqxMzebOpm0dA=="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.3.4.tgz",
+      "integrity": "sha512-I1wz4uxOA52zSBhKmv4KQWLJpCyvfpnDg+eQR6mjpRgV+Ldi14HLPpSUpJklZRldz0fFmGCC/kVmuc/3cPFqCg=="
     },
     "@material-ui/core": {
       "version": "4.12.2",
@@ -26435,9 +26435,9 @@
       }
     },
     "@toniq-labs/design-system": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@toniq-labs/design-system/-/design-system-0.0.11.tgz",
-      "integrity": "sha512-883X5qIZ73YhbtdYuXh+TfpKB6/GH7jZbcdBpiwIlzluzE3zH8878zA+w9jXbFF/Vow5r45m5aZAy8UtFDGeeg==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@toniq-labs/design-system/-/design-system-0.0.14.tgz",
+      "integrity": "sha512-6Ckjg5iPu9faSSsbYUx32q1TS/GmJ9Q2Sxp4EyMQp+Jikacf8i00WBtut0WzL2ooP0ez7l88sPoohPt0CzFb0Q==",
       "requires": {
         "augment-vir": "2.2.1",
         "element-vir": "5.5.1",
@@ -35049,18 +35049,18 @@
       }
     },
     "lit-element": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.2.0.tgz",
-      "integrity": "sha512-HbE7yt2SnUtg5DCrWt028oaU4D5F4k/1cntAFHTkzY8ZIa8N0Wmu92PxSxucsQSOXlODFrICkQ5x/tEshKi13g==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.2.2.tgz",
+      "integrity": "sha512-6ZgxBR9KNroqKb6+htkyBwD90XGRiqKDHVrW/Eh0EZ+l+iC+u+v+w3/BA5NGi4nizAVHGYvQBHUDuSmLjPp7NQ==",
       "requires": {
         "@lit/reactive-element": "^1.3.0",
         "lit-html": "^2.2.0"
       }
     },
     "lit-html": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.6.tgz",
-      "integrity": "sha512-xOKsPmq/RAKJ6dUeOxhmOYFjcjf0Q7aSdfBJgdJkOfCUnkmmJPxNrlZpRBeVe1Gg50oYWMlgm6ccAE/SpJgSdw==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.7.tgz",
+      "integrity": "sha512-JhqiAwO1l03kRe68uBZ0i2x4ef2S5szY9vvP411nlrFZIpKK4/hwnhA/15bqbvxe1lV3ipBdhaOzHmyOk7QIRg==",
       "requires": {
         "@types/trusted-types": "^2.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",
-    "@toniq-labs/design-system": "0.0.11",
+    "@toniq-labs/design-system": "0.0.14",
     "@toruslabs/openlogin": "^1.4.0",
     "assert": "^2.0.0",
     "axios": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",
-    "@toniq-labs/design-system": "0.0.14",
+    "@toniq-labs/design-system": "0.0.15",
     "@toruslabs/openlogin": "^1.4.0",
     "assert": "^2.0.0",
     "axios": "^0.25.0",

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -3,13 +3,10 @@ import { useNavigate } from "react-router";
 import AppBar from "@material-ui/core/AppBar";
 import { createSearchParams } from 'react-router-dom';
 import CssBaseline from "@material-ui/core/CssBaseline";
-import Button from "@material-ui/core/Button";
 import Toolbar from "@material-ui/core/Toolbar";
 import Typography from "@material-ui/core/Typography";
 import Wallet from "../components/Wallet";
-import MenuIcon from "@material-ui/icons/Menu";
-import AccountBalanceWalletIcon from '@material-ui/icons/AccountBalanceWallet';
-import { IconButton, makeStyles } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core";
 import { ToniqToggleButton, ToniqIcon, ToniqButton, ToniqInput } from '@toniq-labs/design-system/dist/esm/elements/react-components';
 import { Rocket24Icon, BuildingStore24Icon, Geometry24Icon, Lifebuoy24Icon, EntrepotLogo144Icon, toniqColors, cssToReactStyleObject, Wallet24Icon, toniqFontStyles, Menu24Icon, Icp24Icon, LoaderAnimated24Icon, Infinity24Icon, Search24Icon } from '@toniq-labs/design-system';
 import extjs from '../ic/extjs.js';
@@ -147,10 +144,10 @@ export default function Navbar(props) {
           />
           <ToniqButton
             className={`toniq-button-outline ${classes.icpButton}`}
-            style={{marginLeft: '8px', alignSelf: 'center'}}
+            style={{width: '120px', marginLeft: '8px', alignSelf: 'center', ...cssToReactStyleObject(toniqFontStyles.boldMonospaceFont), fontSize: '19px'}}
             onClick={handleDrawerToggle}
             icon={balance === undefined ? props.account ? LoaderAnimated24Icon : Wallet24Icon : Icp24Icon}
-            text={balance === undefined ? '' : icpToString(balance)}
+            text={balance === undefined ? '' : icpToString(balance, true, true)}
           ></ToniqButton>
           {open && (
             <div className={classes.smallScreenNav} onClick={() => setOpen(false)}>
@@ -188,9 +185,9 @@ const useStyles = makeStyles((theme) => {
   
   // ideally this value would get calculated at run time based on how wide the nav
   // bar buttons are
-  const hamburgerBreakPixel = '1250px';
-  const displayIcpBreakPixel = '420px';
-  const searchHiddenBreakPixel = '720px';
+  const hamburgerBreakPixel = '1300px';
+  const displayIcpBreakPixel = '450px';
+  const searchHiddenBreakPixel = '750px';
   const minHamburgerMenuBreakpoint = `@media (min-width:${hamburgerBreakPixel})`;
   const hideIcpBreakpoint = `@media (min-width:${displayIcpBreakPixel})`;
   const displayIcpBreakpoint = `@media (max-width:${displayIcpBreakPixel})`;

--- a/src/components/PriceICP.js
+++ b/src/components/PriceICP.js
@@ -1,36 +1,37 @@
-const _showListingPrice = n => {
+import {truncateNumber} from '../truncation';
+import {cssToReactStyleObject, toniqFontStyles, Icp16Icon, toniqColors} from '@toniq-labs/design-system';
+import {ToniqIcon} from '@toniq-labs/design-system/dist/esm/elements/react-components';
+
+function getIcpPrice(n) {
     n = Number(n) / 100000000;
     return n.toFixed(8).replace(/0{1,6}$/, '');
 };
-const numberWithCommas = x => {
+function numberWithCommas(x) {
     var parts = x.toString().split('.');
     parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
     return parts.join('.');
 };
 
-export function icpToString(price /* BigInt */, clean, volume) {
-  const initialPrice = clean
-    ? numberWithCommas(price)
-    : numberWithCommas(_showListingPrice(price));
-  const formattedPrice = volume
-    ? Number(initialPrice.replace(',', '')) >= 10000
-        ? (Number(initialPrice.replace(',', '')) / 1000).toFixed(1) + 'k'
-        : initialPrice
-    : initialPrice;
+export function icpToString(priceE8s /* BigInt */, convertToIcp, truncate) {
+  const initialPrice = convertToIcp
+    ? getIcpPrice(priceE8s)
+    : priceE8s;
   
-  return formattedPrice;
+  if (truncate) {
+    return truncateNumber(initialPrice);
+  } else {
+    return numberWithCommas(initialPrice);
+  }
 }
 
 export default function PriceICP(props) {
     return (
-        <>
-            <img
-                style={{verticalAlign: 'top'}}
-                src={'/currencies/icp.png'}
-                height={props.size ?? 18}
-                width={props.size ?? 18}
-            />{' '}
-            {icpToString(props.price, props.clean, props.volume)}
-        </>
+        <span style={{display: 'inline-flex', alignItems: 'center', gap: '4px'}}>
+        
+            <ToniqIcon icon={Icp16Icon}/>
+            <span style={cssToReactStyleObject(toniqFontStyles.boldMonospaceFont)}>
+                {icpToString(props.price, !props.clean, props.volume)}
+            </span>
+        </span>
     );
 }

--- a/src/truncation.js
+++ b/src/truncation.js
@@ -1,0 +1,69 @@
+const truncationSuffixes = [
+    '', // below 1000
+    'k', // thousand
+    'M', // million
+    'B', // billion
+    'T', // trillion
+    'P', // peta-, quadrillion
+    'E', // exa- quintillion
+    'Z', // zetta- sextillion
+    'Y', // yotta- septillion
+];
+
+function recursiveTruncation(
+    value,
+    recursionDepth = 0,
+    decimalValues = '',
+) {
+    if (value.includes('e+')) {
+        throw new Error(`Number is too large, it cannot be truncated: ${value}`);
+    } else if (value.includes('e-')) {
+        throw new Error(`Number is too small, it cannot be truncated: ${value}`);
+    }
+    const split = value.split('.');
+    decimalValues = split[1] ?? decimalValues;
+    const amount = split[0] ?? '';
+    if (amount.length > 3) {
+        decimalValues = amount.slice(-3);
+        return recursiveTruncation(amount.slice(0, -3), recursionDepth + 1, decimalValues);
+    }
+
+    return {
+        value: amount,
+        decimalValues,
+        recursionDepth,
+    };
+}
+
+const maxDecimals = 4;
+
+/**
+ * This truncates a number such that is will never use commas and will at a max have 6 characters
+ * including suffix (M, B, T, for Million, Billion, Trillion, etc.) and decimal point.
+ */
+export function truncateNumber(originalValue) {
+    try {
+        const value = typeof originalValue === 'number' ? originalValue : Number(originalValue);
+        if (isNaN(value)) {
+            throw new Error(`${originalValue} could not be converted into a number.`);
+        }
+
+        const results = recursiveTruncation(String(value));
+
+        const suffix = truncationSuffixes[results.recursionDepth];
+
+        if (suffix === undefined) {
+            throw new Error(`Number is too large, could not truncate: ${value}`);
+        }
+
+        const decimalPlaces = maxDecimals - (results.value.length - 1) - suffix.length;
+
+        const decimalValues = results.decimalValues.replace(/0+$/, '').slice(0, decimalPlaces);
+        const withDecimal = decimalValues.length ? `.${decimalValues}` : '';
+
+        return `${results.value}${withDecimal}${suffix}`;
+    } catch (error) {
+        console.error(error);
+        return String(originalValue);
+    }
+}

--- a/src/views/Marketplace.js
+++ b/src/views/Marketplace.js
@@ -18,6 +18,7 @@ import TextField from '@material-ui/core/TextField';
 import PriceICP from '../components/PriceICP';
 import { EntrepotUpdateStats, EntrepotAllStats } from '../utils';
 import {isToniqEarnCollection} from '../location/toniq-earn-collections';
+import {cssToReactStyleObject, toniqFontStyles} from '@toniq-labs/design-system';
 function useInterval(callback, delay) {
   const savedCallback = React.useRef();
 
@@ -246,8 +247,8 @@ export default function Marketplace(props) {
                                 <strong><PriceICP volume={true} clean={true} price={stats.find(a => a.canister == collection.canister).stats.total} size={20} /></strong>
                               </Grid>
                               <Grid style={{borderRight:"1px dashed #ddd"}} item md={4}>
-                                <span style={{color:"#00d092"}}>Listings</span><br />
-                                <strong>{stats.find(a => a.canister == collection.canister).stats.listings}</strong>
+                                <span style={{color:"#00d092",}}>Listings</span><br />
+                                <strong style={cssToReactStyleObject(toniqFontStyles.boldMonospaceFont)}>{stats.find(a => a.canister == collection.canister).stats.listings}</strong>
                               </Grid>
                               <Grid item md={4}>
                                 <span style={{color:"#00d092"}}>Floor Price</span><br />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1433,9 +1433,9 @@
   "version" "1.0.4"
 
 "@lit/reactive-element@^1.3.0":
-  "integrity" "sha512-A2e18XzPMrIh35nhIdE4uoqRzoIpEU5vZYuQN4S3Ee1zkGdYC27DP12pewbw/RLgPHzaE4kx/YqxMzebOpm0dA=="
-  "resolved" "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.3.2.tgz"
-  "version" "1.3.2"
+  "integrity" "sha512-I1wz4uxOA52zSBhKmv4KQWLJpCyvfpnDg+eQR6mjpRgV+Ldi14HLPpSUpJklZRldz0fFmGCC/kVmuc/3cPFqCg=="
+  "resolved" "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.3.4.tgz"
+  "version" "1.3.4"
 
 "@material-ui/core@^4.0.0", "@material-ui/core@^4.11.3", "@material-ui/core@^4.11.4", "@material-ui/core@^4.12.1":
   "integrity" "sha512-Q1npB8V73IC+eV2X6as+g71MpEGQwqKHUI2iujY62npk35V8nMx/bUXAHjv5kKG1BZ8s8XUWoG6s/VkjYPjjQA=="
@@ -2026,10 +2026,10 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-"@toniq-labs/design-system@0.0.11":
-  "integrity" "sha512-883X5qIZ73YhbtdYuXh+TfpKB6/GH7jZbcdBpiwIlzluzE3zH8878zA+w9jXbFF/Vow5r45m5aZAy8UtFDGeeg=="
-  "resolved" "https://registry.npmjs.org/@toniq-labs/design-system/-/design-system-0.0.11.tgz"
-  "version" "0.0.11"
+"@toniq-labs/design-system@0.0.14":
+  "integrity" "sha512-6Ckjg5iPu9faSSsbYUx32q1TS/GmJ9Q2Sxp4EyMQp+Jikacf8i00WBtut0WzL2ooP0ez7l88sPoohPt0CzFb0Q=="
+  "resolved" "https://registry.npmjs.org/@toniq-labs/design-system/-/design-system-0.0.14.tgz"
+  "version" "0.0.14"
   dependencies:
     "augment-vir" "2.2.1"
     "element-vir" "5.5.1"
@@ -8436,17 +8436,17 @@
   "version" "1.1.6"
 
 "lit-element@^3.2.0":
-  "integrity" "sha512-HbE7yt2SnUtg5DCrWt028oaU4D5F4k/1cntAFHTkzY8ZIa8N0Wmu92PxSxucsQSOXlODFrICkQ5x/tEshKi13g=="
-  "resolved" "https://registry.npmjs.org/lit-element/-/lit-element-3.2.0.tgz"
-  "version" "3.2.0"
+  "integrity" "sha512-6ZgxBR9KNroqKb6+htkyBwD90XGRiqKDHVrW/Eh0EZ+l+iC+u+v+w3/BA5NGi4nizAVHGYvQBHUDuSmLjPp7NQ=="
+  "resolved" "https://registry.npmjs.org/lit-element/-/lit-element-3.2.2.tgz"
+  "version" "3.2.2"
   dependencies:
     "@lit/reactive-element" "^1.3.0"
     "lit-html" "^2.2.0"
 
 "lit-html@^2.2.0":
-  "integrity" "sha512-xOKsPmq/RAKJ6dUeOxhmOYFjcjf0Q7aSdfBJgdJkOfCUnkmmJPxNrlZpRBeVe1Gg50oYWMlgm6ccAE/SpJgSdw=="
-  "resolved" "https://registry.npmjs.org/lit-html/-/lit-html-2.2.6.tgz"
-  "version" "2.2.6"
+  "integrity" "sha512-JhqiAwO1l03kRe68uBZ0i2x4ef2S5szY9vvP411nlrFZIpKK4/hwnhA/15bqbvxe1lV3ipBdhaOzHmyOk7QIRg=="
+  "resolved" "https://registry.npmjs.org/lit-html/-/lit-html-2.2.7.tgz"
+  "version" "2.2.7"
   dependencies:
     "@types/trusted-types" "^2.0.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2026,10 +2026,10 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-"@toniq-labs/design-system@0.0.14":
-  "integrity" "sha512-6Ckjg5iPu9faSSsbYUx32q1TS/GmJ9Q2Sxp4EyMQp+Jikacf8i00WBtut0WzL2ooP0ez7l88sPoohPt0CzFb0Q=="
-  "resolved" "https://registry.npmjs.org/@toniq-labs/design-system/-/design-system-0.0.14.tgz"
-  "version" "0.0.14"
+"@toniq-labs/design-system@0.0.15":
+  "integrity" "sha512-NI2yXXQcgjo2WP6MH0RRBs1ieyBR6k31mcDBVGvU1t4ajLU+/IOr2P5exJ5qwNYcKkkEWTa5KpG49KCNXYczsg=="
+  "resolved" "https://registry.npmjs.org/@toniq-labs/design-system/-/design-system-0.0.15.tgz"
+  "version" "0.0.15"
   dependencies:
     "augment-vir" "2.2.1"
     "element-vir" "5.5.1"


### PR DESCRIPTION
- change ICP price displays to a monospace font for consistent sizing:
    ![nft-card-monospace](https://user-images.githubusercontent.com/1205860/181047650-78aee28b-3326-4b93-b1af-d657134bf81b.png)
    ![markeplace-card-with-monospace](https://user-images.githubusercontent.com/1205860/181047642-90053f64-1b72-4205-853b-5dfa86d59493.png)
- modify ICP price truncation to produce number strings that are never greater than 6 in length
- add fixed size to wallet button so when the user's balance is loaded, the nav bar doesn't move:
    ![fixed-button-size](https://user-images.githubusercontent.com/1205860/181047634-7c6423a2-1541-4900-91af-52afe60be92d.png)

    https://user-images.githubusercontent.com/1205860/181047647-73068187-610f-4c32-816b-86f5de3f7f7a.mp4