### PR TITLE
move the filters text and show filter logic into WithFilterPanel

### DIFF
--- a/src/components/shared/WithFilterPanel.js
+++ b/src/components/shared/WithFilterPanel.js
@@ -100,6 +100,36 @@ export function WithFilterPanel(props) {
               margin-top: var(--filter-element-padding);
             }
 
+            .with-filter-panel .controls-row-header {
+              margin-bottom: 32px;
+            }
+
+            .with-filter-panel .filter-sort-row {
+              display: flex;
+              align-items: center;
+              gap: 16px;
+              ${toniqFontStyles.boldParagraphFont};
+            }
+
+            .with-filter-panel .filters-trigger {
+              display: flex;
+              gap: 16px;
+            }
+
+            .with-filter-panel .filter-and-icon {
+              cursor: pointer;
+              margin-left: 16px;
+              gap: 8px;
+              flex-shrink: 0;
+            }
+
+            .with-filter-panel .other-controls {
+              display: flex;
+              align-items: center;
+              justify-content: space-between;
+              flex-grow: 1;
+            }
+
             @media (max-width: 800px) {
               .with-filter-panel {
                 flex-direction: column;
@@ -119,13 +149,23 @@ export function WithFilterPanel(props) {
               .with-filter-panel {
                 --filter-element-padding: 16px;
               }
+              .with-filter-panel .filter-sort-row {
+                flex-direction: column;
+                align-items: unset;
+              }
+              .with-filter-panel .filters-dot-thing {
+                opacity: 0;
+              }
+              .with-filter-panel .other-controls {
+                margin-left: 16px;
+              }
             }
           `),
         }}
       ></style>
 
       <div className={`${props.className ?? ''} with-filter-panel`} style={{...props.style}}>
-        <div className={`${props.showFilterPanel ? 'show-left-panel' : ''} left-filter-panel`}>
+        <div className={`${props.showFilters ? 'show-left-panel' : ''} left-filter-panel`}>
           <div className="left-filter-panel-header">
             <div className="filter-text-and-icon">
               <ToniqIcon icon={Filter24Icon} />
@@ -133,13 +173,44 @@ export function WithFilterPanel(props) {
             </div>
             <ToniqIcon
               className="close-filter-panel-icon"
-              onClick={() => props.onFilterClose()}
+              onClick={() => {
+                props.onShowFiltersChange(false);
+              }}
               icon={X24Icon}
             />
           </div>
           <div className="filter-controls-wrapper">{props.filterControlChildren}</div>
         </div>
-        <div className="right-section">{props.children}</div>
+        <div className="right-section">
+          <div className="controls">
+            <div className="filter-sort-row">
+              <div className="filters-trigger">
+                <div
+                  className="filter-and-icon"
+                  style={{
+                    display: props.showFilters ? 'none' : 'flex',
+                  }}
+                  onClick={() => {
+                    props.onShowFiltersChange(true);
+                  }}
+                >
+                  <ToniqIcon icon={Filter24Icon} />
+                  <span>Filters</span>
+                </div>
+                <span
+                  className="filters-dot-thing"
+                  style={{
+                    display: props.showFilters ? 'none' : 'flex',
+                  }}
+                >
+                  •
+                </span>
+              </div>
+              <div className="other-controls">{props.otherControlsChildren}</div>
+            </div>
+          </div>
+          <div>{props.children}</div>
+        </div>
       </div>
     </>
   );

--- a/src/views/Marketplace.js
+++ b/src/views/Marketplace.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {makeStyles, useTheme} from '@material-ui/core/styles';
+import {makeStyles} from '@material-ui/core/styles';
 import {useSearchParams} from 'react-router-dom';
 import {useNavigate} from 'react-router';
 import {Link} from 'react-router-dom';
@@ -13,7 +13,6 @@ import {
   LoaderAnimated24Icon,
   Icp16Icon,
   Search24Icon,
-  Filter24Icon,
   ArrowsSort24Icon,
 } from '@toniq-labs/design-system';
 import {NftCard} from '../components/shared/NftCard';
@@ -95,43 +94,6 @@ const useStyles = makeStyles(theme => ({
     // 8px here plus 24px padding on wrapper makes 32px total between this and the nav bar
     marginTop: '8px',
     marginBottom: '24px',
-  },
-  filterSortRow: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '16px',
-    ...cssToReactStyleObject(toniqFontStyles.boldParagraphFont),
-    [filterOnTopBreakPoint]: {
-      flexDirection: 'column',
-      alignItems: 'unset',
-    },
-  },
-  filtersTrigger: {
-    display: 'flex',
-    gap: '16px',
-  },
-  filtersDotThing: {
-    [filterOnTopBreakPoint]: {
-      opacity: 0,
-    },
-  },
-  collectionsAndSort: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    flexGrow: 1,
-    [filterOnTopBreakPoint]: {
-      marginLeft: '16px',
-    },
-  },
-  marketplaceControls: {
-    marginBottom: '32px',
-  },
-  filterAndIcon: {
-    cursor: 'pointer',
-    marginLeft: '16px',
-    gap: '8px',
-    flexShrink: 0,
   },
   media: {
     cursor: 'pointer',
@@ -534,9 +496,9 @@ export default function Marketplace(props) {
             }}
           />
           <WithFilterPanel
-            showFilterPanel={showFilters}
-            onFilterClose={() => {
-              setShowFilters(false);
+            showFilters={showFilters}
+            onShowFiltersChange={newShowFilters => {
+              setShowFilters(newShowFilters);
             }}
             filterControlChildren={
               <>
@@ -609,57 +571,33 @@ export default function Marketplace(props) {
                 </div>
               </>
             }
+            otherControlsChildren={
+              <>
+                <span
+                  style={{
+                    ...cssToReactStyleObject(toniqFontStyles.paragraphFont),
+                    color: toniqColors.pageSecondary.foregroundColor,
+                  }}
+                >
+                  {filteredAndSortedCollections.length} Collections
+                </span>
+                <ToniqDropdown
+                  style={{
+                    '--toniq-accent-secondary-background-color': 'transparent',
+                    width: '360px',
+                  }}
+                  icon={ArrowsSort24Icon}
+                  selectedLabelPrefix="Sort By:"
+                  selected={sort}
+                  onSelectChange={event => {
+                    console.log(event.detail);
+                    setSort(event.detail);
+                  }}
+                  options={sortOptions}
+                />
+              </>
+            }
           >
-            <div className={classes.marketplaceControls}>
-              <div className={classes.filterSortRow}>
-                <div className={classes.filtersTrigger}>
-                  <div
-                    className={classes.filterAndIcon}
-                    style={{
-                      display: showFilters ? 'none' : 'flex',
-                    }}
-                    onClick={() => {
-                      setShowFilters(true);
-                    }}
-                  >
-                    <ToniqIcon icon={Filter24Icon} />
-                    <span>Filters</span>
-                  </div>
-                  <span
-                    className={classes.filtersDotThing}
-                    style={{
-                      display: showFilters ? 'none' : 'flex',
-                    }}
-                  >
-                    •
-                  </span>
-                </div>
-                <div className={classes.collectionsAndSort}>
-                  <span
-                    style={{
-                      ...cssToReactStyleObject(toniqFontStyles.paragraphFont),
-                      color: toniqColors.pageSecondary.foregroundColor,
-                    }}
-                  >
-                    {filteredAndSortedCollections.length} Collections
-                  </span>
-                  <ToniqDropdown
-                    style={{
-                      '--toniq-accent-secondary-background-color': 'transparent',
-                      width: '360px',
-                    }}
-                    icon={ArrowsSort24Icon}
-                    selectedLabelPrefix="Sort By:"
-                    selected={sort}
-                    onSelectChange={event => {
-                      console.log(event.detail);
-                      setSort(event.detail);
-                    }}
-                    options={sortOptions}
-                  />
-                </div>
-              </div>
-            </div>
             <Grid
               container
               direction="row"


### PR DESCRIPTION
Moves the `Filters` text that opens the filter panel into `WithFilterPanel` so it can be shared between all uses of it.

This is the part that got moved:
![filters-row](https://user-images.githubusercontent.com/1205860/187339829-ad543fdc-0918-4ad5-a55c-266a2e827529.png)

Consumers of `WithFilterPanel` will then be able to customize the elements to the right of the `Filters` text.