### PR TITLE
add dfinity origins to do not cache list

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -253,6 +253,9 @@ const clipboardCopy = text => {
         return 'https://images.entrepot.app/tnc/' + collection + '/' + id + ref;
       if (collection === 'e3izy-jiaaa-aaaah-qacbq-cai')
         return 'https://images.entrepot.app/tnc/' + collection + '/' + id + ref;
+      if (collection === 'xjjax-uqaaa-aaaal-qbfgq-cai')
+        return 'https://images.entrepot.app/tnc/' + collection + '/' + id + ref;
+      
 
       //end of section
 


### PR DESCRIPTION
Novica had some problems with testing because of caching, but I also think we're going to need to keep it this way permanently (because images will change for this collection).