### PR TITLE
Set MUI Tabs variant to scrollable

### DIFF
--- a/src/components/sale/V2SaleComponent.js
+++ b/src/components/sale/V2SaleComponent.js
@@ -444,10 +444,11 @@ export default function V2SaleComponent(props) {
                                         value={currentPriceGroup}
                                         indicatorColor="primary"
                                         textColor="primary"
-                                        centered={window.innerWidth < 960 ? false : true}
-                                        scrollButtons="on"
-                                        allowScrollButtonsMobile
-                                        variant="scrollable"
+                                        centered={false}
+                                        scrollButtons={window.innerWidth < 960 ? 'on' : 'auto'}
+                                        variant={
+                                            window.innerWidth < 960 ? 'scrollable' : 'standard'
+                                        }
                                         onChange={(e, nv) => {
                                             setCurrentPriceGroup(nv);
                                         }}

--- a/src/components/sale/V2SaleComponent.js
+++ b/src/components/sale/V2SaleComponent.js
@@ -378,7 +378,11 @@ export default function V2SaleComponent(props) {
                         <strong>SOLD</strong>
                         <br />
                         <span style={{fontWeight: 'bold', color: 'rgb(189 1 1)', fontSize: '2em'}}>
-                            {sold !== false ? (collection.canister==="7i54s-nyaaa-aaaal-abomq-cai" ? (sold+362) : sold) : 'Loading...'}
+                            {sold !== false
+                                ? collection.canister === '7i54s-nyaaa-aaaal-abomq-cai'
+                                    ? sold + 362
+                                    : sold
+                                : 'Loading...'}
                         </span>
                     </Grid>
                     <Grid className={classes.stat} item xs={10}>
@@ -441,10 +445,9 @@ export default function V2SaleComponent(props) {
                                         indicatorColor="primary"
                                         textColor="primary"
                                         centered={window.innerWidth < 960 ? false : true}
-                                        scrollButtons={window.innerWidth < 960 ? 'on' : 'auto'}
-                                        variant={
-                                            window.innerWidth < 960 ? 'scrollable' : 'standard'
-                                        }
+                                        scrollButtons="on"
+                                        allowScrollButtonsMobile
+                                        variant="scrollable"
                                         onChange={(e, nv) => {
                                             setCurrentPriceGroup(nv);
                                         }}


### PR DESCRIPTION
Added fix for multi tabs getting cut off when larger than visible width by making tabs scrollable (same behavior as mobile)
![Screen Shot 2022-12-13 at 7 47 55 AM](https://user-images.githubusercontent.com/99699764/207184053-1d23f621-7823-4786-854d-2210ea1c14d2.png)
