### PR TITLE
Set MUI Tabs variant to scrollable

### DIFF
--- a/src/components/sale/V2SaleComponent.js
+++ b/src/components/sale/V2SaleComponent.js
@@ -445,10 +445,9 @@ export default function V2SaleComponent(props) {
                                         indicatorColor="primary"
                                         textColor="primary"
                                         centered={false}
-                                        scrollButtons={window.innerWidth < 960 ? 'on' : 'auto'}
-                                        variant={
-                                            window.innerWidth < 960 ? 'scrollable' : 'standard'
-                                        }
+                                        scrollButtons="on"
+                                        allowScrollButtonsMobile
+                                        variant="scrollable"
                                         onChange={(e, nv) => {
                                             setCurrentPriceGroup(nv);
                                         }}


### PR DESCRIPTION
Added fix for multi tabs getting cut off when larger than visible width by making tabs scrollable (same behavior as mobile)
![Screen Shot 2022-12-13 at 7 54 13 AM](https://user-images.githubusercontent.com/99699764/207189708-34fdd06d-d581-4753-b6ac-ceebda0abb98.png)
